### PR TITLE
Fixed cmime_util_get_mimetype on Mac OS X

### DIFF
--- a/src/cmime_util.c
+++ b/src/cmime_util.c
@@ -61,7 +61,7 @@ char *cmime_util_get_mimetype(const char *filename) {
     assert(filename);
     
     /* build up the command string */
-    asprintf(&command,"%s %s",FILE_EXECUTABLE,filename);
+    asprintf(&command,"%s '%s'",FILE_EXECUTABLE,filename);
 
     /* open the pipe and try to read command output */
     fh = popen(command, "r");
@@ -77,10 +77,10 @@ char *cmime_util_get_mimetype(const char *filename) {
         strncpy(retval, buf, strlen(buf));
         retval[strlen(retval)] = '\0';
         free(buf);
-        fclose(fh);
+        pclose(fh);
         return(retval);
     } else {
-        fclose(fh);
+        pclose(fh);
         return(NULL);
     }
 }


### PR DESCRIPTION
in function cmime_util_get_mimetype:

- Quote filename so it works even if it contains spaces
- Close pipe handle using pclose(3) instead of fclose(3). See [why-does-popen-only-work-once](http://stackoverflow.com/questions/3623730/why-does-popen-only-work-once)