### PR TITLE
Fixed random number generation

### DIFF
--- a/src/cmime_message.c
+++ b/src/cmime_message.c
@@ -699,10 +699,8 @@ char *cmime_message_generate_boundary(void) {
                                "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                                "0123456789._-=";
 
-    srand(time(NULL));
-
     for ( i = 0; i < 20; ++i ) {
-        str[i] = text[rand() % (sizeof text - 1)];
+        str[i] = text[cmime_util_rand() % (sizeof text - 1)];
     }
     str[20] = '\0';
     
@@ -992,10 +990,9 @@ char *cmime_message_generate_message_id(void) {
     gethostname(hostname,MAXHOSTNAMELEN);
         
     mid = (char *)malloc(20 + strlen(hostname));
-    srandom(getpid() ^ time((time_t *) 0));
     for(i=0; i < 2; i++) {
         for (i2=0; i2<8; i2++) 
-            mid[pos++] = base36[random() % 36];
+            mid[pos++] = base36[cmime_util_rand() % 36];
         
         if (i==0)
             mid[pos++] = '.';

--- a/src/cmime_util.c
+++ b/src/cmime_util.c
@@ -176,3 +176,15 @@ CMimeInfo_T *cmime_util_info_get_from_file(const char *filename) {
 
     return(mi);   
 }
+
+int cmime_util_rand()
+{
+    static unsigned seed = 0;
+    
+    if(seed == 0)
+        seed = time((time_t*)0) ^ getpid();
+
+    int result = rand_r(&seed);
+    return result;
+}
+

--- a/src/cmime_util.h
+++ b/src/cmime_util.h
@@ -39,6 +39,8 @@ extern "C" {
 #include <string.h>
 #include <assert.h>
 #include <errno.h>
+#include <time.h>
+#include <unistd.h>
 
 /*!
  * @struct CMimeInfo_T cmime_util.h
@@ -87,6 +89,13 @@ CMimeInfo_T *cmime_util_info_get_from_string(const char *s);
  * @returns a newly allocated CMimeInfo_T object, or NULL on failure
  */
 CMimeInfo_T *cmime_util_info_get_from_file(const char *filename);
+
+/*!
+ * @fn int cmime_util_rand()
+ * @brief Generate a random number from 0 to RAND_MAX
+ * @returns a random integer from 0 to RAND_MAX
+ */
+int cmime_util_rand();
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The current random number generation has a bug where if cmime_message_generate_boundary() is called two times in less than one second time interval, it spits the same result. This commit fixes that.